### PR TITLE
Fixed preliminary free() call

### DIFF
--- a/clDeviceQuery.cpp
+++ b/clDeviceQuery.cpp
@@ -253,8 +253,8 @@ sProfileString += cBuffer;
   sProfileString += "\n";
   printf("%s", sProfileString.c_str());
 }
-free(clPlatformIDs);
       }
+	free(clPlatformIDs);
     }
   }
 


### PR DESCRIPTION
The free() function was called inside the for loop and freed the memory while still in use.